### PR TITLE
Fix build process to include custom domains setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "deploy": "gh-pages -d web-build",
-    "predeploy": "expo build:web",
+    "predeploy": "expo build:web && cp CNAME ./web-build/",
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",


### PR DESCRIPTION
## Summary
Fix build process to include custom domains setup.
Before deployment the project is built using `expo build:web` command which does not copy `CNAME` file. This PR adds a manual coping after main build.

## Screenshot
<img width="418" alt="d" src="https://user-images.githubusercontent.com/74097/139577003-5760d505-282b-4774-aaaf-dadcc9739c67.png">

